### PR TITLE
Add Vite/Rollup plugin variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 lib
 node_modules
 npm-debug.log
+.codex-reviews/

--- a/README.md
+++ b/README.md
@@ -41,3 +41,24 @@ ${mod.license.name} (${mod.license.url})`,
         surviveLicenseErrors: true,
       }),
 ```
+
+#### Vite
+
+The same checker is available as a Vite/Rollup plugin, imported from the
+`/vite` subpath. It walks the Rollup module graph (all loaded modules,
+including externalized dependencies) instead of webpack stats;
+`devDependencies` and the webpack-specific `excludeUserRequest` filter don't
+apply. `exclude` here is matched against resolved module ids.
+
+```javascript
+import licenseChecker from '@jetbrains/ring-ui-license-checker/vite'
+
+export default {
+  plugins: [
+    licenseChecker({
+      filename: 'third-party-libs.xml',
+      forceAddPackages: ['some-runtime-dep'],
+    }),
+  ],
+}
+```

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "Ring UI License Checker is webpack plugin intended to generate third-party libraries list with license information from dependency tree",
   "main": "lib/index.js",
   "files": [
-    "lib"
+    "lib",
+    "vite.js"
   ],
   "scripts": {
     "build": "babel src --out-dir lib --source-maps",
+    "test": "npm run build && node test/vite.test.js",
     "precommit": "npm run lint",
     "commit": "git-cz",
     "prerelease:ci": "npm run build",

--- a/src/get-licences.js
+++ b/src/get-licences.js
@@ -78,75 +78,80 @@ export default function (modules, params, callback) {
   try {
     nlf.find(params, function processModules(err, licenses) {
       if (err) {
-        throw err
+        return callback(err)
       }
 
-      const throwOrWriteError = (({
-        surviveLicenseErrors = false,
-        teamcityMessageStatus = 'ERROR',
-        ignoreTeamcity = false
-      }) => text => {
-        if (!surviveLicenseErrors) {
-          if (!ignoreTeamcity && process.env.TEAMCITY_VERSION) {
-            tsm.buildProblem({
-              description: text
+      let result
+      try {
+        const throwOrWriteError = (({
+          surviveLicenseErrors = false,
+          teamcityMessageStatus = 'ERROR',
+          ignoreTeamcity = false
+        }) => text => {
+          if (!surviveLicenseErrors) {
+            if (!ignoreTeamcity && process.env.TEAMCITY_VERSION) {
+              tsm.buildProblem({
+                description: text
+              })
+            } else {
+              throw new Error(text)
+            }
+          } else if (!ignoreTeamcity && process.env.TEAMCITY_VERSION) {
+            tsm.message({
+              status: teamcityMessageStatus,
+              text
             })
           } else {
-            throw new Error(text)
+            console.error(text)
           }
-        } else if (!ignoreTeamcity && process.env.TEAMCITY_VERSION) {
-          tsm.message({
-            status: teamcityMessageStatus,
-            text
-          })
-        } else {
-          console.error(text)
-        }
-        return text
-      })(params)
+          return text
+        })(params)
 
-      const result = modules.
-        sort().
-        filter(module => module.indexOf('jetbrains-') !== 0 && module.indexOf('ring-ui') !== 0).
-        map(name => licenses.find(module => module.name === name)).
-        filter(module => module).
-        map(module => {
-          const sources = module.licenseSources
+        result = modules.
+          sort().
+          filter(module => module.indexOf('jetbrains-') !== 0 && module.indexOf('ring-ui') !== 0).
+          map(name => licenses.find(module => module.name === name)).
+          filter(module => module).
+          map(module => {
+            const sources = module.licenseSources
 
-          const licensesCount =
+            const licensesCount =
             sources.package.sources.length +
             sources.license.sources.length +
             sources.readme.sources.length
 
-          let license
-          if (!licensesCount) {
-            license = {
-              name: throwOrWriteError(`No license found for package ${module.name}`),
-              url: 'N/A'
-            }
-          } else {
-            license =
+            let license
+            if (!licensesCount) {
+              license = {
+                name: throwOrWriteError(`No license found for package ${module.name}`),
+                url: 'N/A'
+              }
+            } else {
+              license =
               chooseLicense(sources.package.sources) ||
               chooseLicense(sources.license.sources) ||
               chooseLicense(sources.readme.sources)
 
-            if (!license) {
-              license = {
-                name: throwOrWriteError(`No *permissive* license found for package ${module.name}`),
-                url: 'N/A'
+              if (!license) {
+                license = {
+                  name: throwOrWriteError(`No *permissive* license found for package ${module.name}`),
+                  url: 'N/A'
+                }
               }
             }
-          }
 
-          return {
-            license,
-            name: module.name,
-            version: module.version,
-            url: npmUrlPrefix + module.name
-          }
-        })
+            return {
+              license,
+              name: module.name,
+              version: module.version,
+              url: npmUrlPrefix + module.name
+            }
+          })
 
-      callback(null, result)
+      } catch (e) {
+        return callback(e)
+      }
+      return callback(null, result)
     })
   } catch (e) {
     callback(e)

--- a/src/vite.js
+++ b/src/vite.js
@@ -4,7 +4,7 @@ import {builtinModules} from 'module'
 import getLicences from './get-licences'
 import format from './format'
 
-const builtins = new Set(builtinModules)
+const builtins = new Set(builtinModules || [])
 
 // `fs`, `path`, `fs/promises`, `node:fs` -> true
 function isBuiltin(id) {

--- a/src/vite.js
+++ b/src/vite.js
@@ -1,0 +1,95 @@
+import {join, resolve as resolvePath} from 'path'
+import {builtinModules} from 'module'
+
+import getLicences from './get-licences'
+import format from './format'
+
+const builtins = new Set(builtinModules)
+
+// `fs`, `path`, `fs/promises`, `node:fs` -> true
+function isBuiltin(id) {
+  const bare = id.replace(/^node:/, '')
+  return id.startsWith('node:') || builtins.has(bare) || builtins.has(bare.split('/')[0])
+}
+
+// node_modules/@scope/pkg/dist/x.js -> @scope/pkg ; node_modules/pkg/x.js -> pkg
+// bare external id (react, @scope/pkg) -> same. builtins & relative -> null.
+export function packageNameFromId(id, isExternal) {
+  const parts = id.split('node_modules/')
+  let head
+  if (parts.length > 1) {
+    head = parts[parts.length - 1]
+  } else if (isExternal && /^(@[^/]+\/)?[^./]/.test(id) && !isBuiltin(id)) {
+    head = id
+  } else {
+    return null
+  }
+  const seg = head.split('/')
+  return seg[0][0] === '@' ? `${seg[0]}/${seg[1]}` : seg[0]
+}
+
+// Vite/Rollup plugin variant. Same options as the webpack plugin, minus
+// webpack-only ones (devDependencies, excludeUserRequest). `exclude` is
+// matched against resolved module ids.
+export default function licenseChecker(options = {}) {
+  const directory = resolvePath(options.directory || process.cwd())
+  const filename = options.filename || 'third-party-libs.xml'
+  // eslint-disable-next-line global-require
+  const pkg = require(join(directory, 'package.json'))
+  const title = options.title || `${pkg.description} Front-End Libraries`
+  const formatModules = options.format || format
+  const exclude = options.exclude && [].concat(options.exclude)
+
+  return {
+    name: 'ring-ui-license-checker',
+    /* eslint-disable-next-line complexity */
+    generateBundle() {
+      const names = new Set(options.modules || [])
+      // reset lastIndex so a reused /g or /y regex stays deterministic across ids
+      const excluded = id => exclude.some(it => {
+        it.lastIndex = 0
+        return it.test(id)
+      })
+      for (const id of this.getModuleIds()) {
+        if (exclude && excluded(id)) {
+          continue
+        }
+        const info = this.getModuleInfo(id)
+        const name = packageNameFromId(id, Boolean(info && info.isExternal))
+        if (name) {
+          names.add(name)
+        }
+      }
+      (options.forceAddPackages || []).forEach(name => names.add(name))
+
+      return new Promise((resolve, reject) => {
+        getLicences(
+          [...names],
+          {
+            directory,
+            production: true,
+            surviveLicenseErrors: options.surviveLicenseErrors,
+            ignoreTeamcity: Boolean(options.ignoreTeamcity),
+            teamcityMessageStatus: options.teamcityMessageStatus
+          },
+          (err, modules) => {
+            if (err) {
+              return reject(err)
+            }
+            const allModules = modules.concat(options.customLicenses || [])
+            try {
+              this.emitFile({
+                type: 'asset',
+                fileName: filename,
+                source: formatModules({title, modules: allModules})
+              })
+            } catch (e) {
+              return reject(e)
+            }
+            return resolve()
+          }
+        )
+      })
+    }
+  }
+}

--- a/src/vite.js
+++ b/src/vite.js
@@ -15,7 +15,7 @@ function isBuiltin(id) {
 // node_modules/@scope/pkg/dist/x.js -> @scope/pkg ; node_modules/pkg/x.js -> pkg
 // bare external id (react, @scope/pkg) -> same. builtins & relative -> null.
 export function packageNameFromId(id, isExternal) {
-  const parts = id.split('node_modules/')
+  const parts = id.split(/node_modules[\\/]/)
   let head
   if (parts.length > 1) {
     head = parts[parts.length - 1]
@@ -24,7 +24,7 @@ export function packageNameFromId(id, isExternal) {
   } else {
     return null
   }
-  const seg = head.split('/')
+  const seg = head.split(/[\\/]/)
   return seg[0][0] === '@' ? `${seg[0]}/${seg[1]}` : seg[0]
 }
 

--- a/test/vite.test.js
+++ b/test/vite.test.js
@@ -1,0 +1,116 @@
+// Runs against the built package: `npm test` (build + this).
+const assert = require('assert')
+
+const licenseChecker = require('../vite')
+const getLicences = require('../lib/get-licences')
+
+const {packageNameFromId} = licenseChecker
+const ASYNC_SETTLE_MS = 50
+
+// --- packageNameFromId ---------------------------------------------------
+assert.strictEqual(packageNameFromId('/a/node_modules/react/index.js'), 'react')
+assert.strictEqual(packageNameFromId('/a/node_modules/@scope/pkg/dist/x.js'), '@scope/pkg')
+assert.strictEqual(packageNameFromId('/a/node_modules/a/node_modules/b/i.js'), 'b')
+assert.strictEqual(packageNameFromId('/src/app.js'), null)
+// externals: bare ids only count when isExternal
+assert.strictEqual(packageNameFromId('react', true), 'react')
+assert.strictEqual(packageNameFromId('@scope/pkg', true), '@scope/pkg')
+assert.strictEqual(packageNameFromId('node:path', true), null)
+assert.strictEqual(packageNameFromId('./local', true), null)
+assert.strictEqual(packageNameFromId('react', false), null)
+// bare Node built-ins (incl. subpaths) are not packages
+assert.strictEqual(packageNameFromId('fs', true), null)
+assert.strictEqual(packageNameFromId('path', true), null)
+assert.strictEqual(packageNameFromId('fs/promises', true), null)
+
+// subpath export resolves to the plugin factory
+const base = licenseChecker({directory: process.cwd()})
+assert.strictEqual(base.name, 'ring-ui-license-checker')
+assert.strictEqual(typeof base.generateBundle, 'function')
+
+// mock Rollup plugin context
+function ctx(ids, externals = []) {
+  const ext = new Set(externals)
+  const emitted = []
+  return {
+    emitted,
+    getModuleIds: () => ids[Symbol.iterator](),
+    getModuleInfo: id => ({isExternal: ext.has(id)}),
+    emitFile(f) {
+      emitted.push(f)
+    }
+  }
+}
+
+async function main() {
+  // `oss-license-name-to-url` is a real dependency of this package
+  const dep = 'oss-license-name-to-url'
+
+  // --- discovery + emit -------------------------------------------------
+  const plugin = licenseChecker({directory: process.cwd(), filename: 'libs.xml'})
+  const c1 = ctx([`/x/node_modules/${dep}/index.js`, '/x/src/app.js'])
+  await plugin.generateBundle.call(c1)
+  assert.strictEqual(c1.emitted.length, 1)
+  assert.strictEqual(c1.emitted[0].fileName, 'libs.xml')
+  assert.ok(c1.emitted[0].source.includes(dep), 'discovered dep must appear in output')
+
+  // --- exclude drops a module by id -------------------------------------
+  const plugin2 = licenseChecker({directory: process.cwd(), exclude: [new RegExp(dep)]})
+  const c2 = ctx([`/x/node_modules/${dep}/index.js`])
+  await plugin2.generateBundle.call(c2)
+  assert.ok(!c2.emitted[0].source.includes(dep), 'excluded dep must not appear')
+
+  // --- a global /g exclude regex stays deterministic across ids ---------
+  const plugin2b = licenseChecker({directory: process.cwd(), exclude: [new RegExp(dep, 'g')]})
+  const c2b = ctx([`/x/node_modules/${dep}/a.js`, `/x/node_modules/${dep}/b.js`])
+  await plugin2b.generateBundle.call(c2b)
+  assert.ok(!c2b.emitted[0].source.includes(dep), 'global regex must exclude every matching id')
+
+  // --- a relative directory resolves the manifest -----------------------
+  const pluginRel = licenseChecker({directory: '.'})
+  const cRel = ctx([`/x/node_modules/${dep}/index.js`])
+  await pluginRel.generateBundle.call(cRel)
+  assert.ok(cRel.emitted[0].source.includes(dep), 'relative directory must load and emit')
+
+  // --- externals discovered from bare ids -------------------------------
+  const plugin3 = licenseChecker({directory: process.cwd()})
+  const c3 = ctx([dep], [dep])
+  await plugin3.generateBundle.call(c3)
+  assert.ok(c3.emitted[0].source.includes(dep), 'external dep must appear')
+
+  // --- rejection path: a throwing formatter rejects the hook ------------
+  const plugin4 = licenseChecker({
+    directory: process.cwd(),
+    format: () => {
+      throw new Error('boom')
+    }
+  })
+  await assert.rejects(
+    plugin4.generateBundle.call(ctx([`/x/node_modules/${dep}/index.js`])),
+    /boom/
+  )
+
+  // --- getLicences invokes a throwing success callback exactly once -----
+  await new Promise((resolve, reject) => {
+    let calls = 0
+    const onUncaught = () => {} // swallow the error re-thrown out of the callback
+    process.once('uncaughtException', onUncaught)
+    getLicences([], {directory: process.cwd(), production: true}, () => {
+      calls += 1
+      setTimeout(() => {
+        process.removeListener('uncaughtException', onUncaught)
+        return calls === 1 ? resolve() : reject(new Error(`callback called ${calls}x`))
+      }, ASYNC_SETTLE_MS)
+      throw new Error('callback throws')
+    })
+  })
+
+  // eslint-disable-next-line no-console
+  console.log('ok')
+}
+
+main().catch(e => {
+  // eslint-disable-next-line no-console
+  console.error(e)
+  process.exitCode = 1
+})

--- a/vite.js
+++ b/vite.js
@@ -1,0 +1,6 @@
+// Expose the plugin factory as the module export (Babel keeps the named
+// `packageNameFromId` export, so add-module-exports won't collapse it).
+const {default: licenseChecker, packageNameFromId} = require('./lib/vite')
+
+licenseChecker.packageNameFromId = packageNameFromId
+module.exports = licenseChecker


### PR DESCRIPTION
## What

Adds a Vite/Rollup plugin variant alongside the existing webpack plugin, imported from the `/vite` subpath:

```js
import licenseChecker from '@jetbrains/ring-ui-license-checker/vite'
```

It hooks `generateBundle`, walks the Rollup module graph, extracts package names from `node_modules` paths and externalized bare ids (skipping Node built-ins like `fs`/`path`/`fs/promises`), and reuses the existing `getLicences` + `format` to emit the same XML asset.

## Why

The checker previously only worked as a webpack plugin. Vite/Rollup builds had no equivalent.

## Notes for reviewers

- **Subpath export**: shipped via a root `vite.js` shim (added to `files`). The mixed default+named export in `src/vite.js` stops `add-module-exports` from collapsing, so the shim unwraps `default` and re-attaches `packageNameFromId`.
- **`getLicences` hardening**: async errors from `nlf.find` / license processing now go through the callback instead of being thrown into the void, and `callback(null, result)` runs *outside* the try so a throwing consumer callback can't double-complete. This also fixes latent uncaught-error behavior on the webpack path.
- **Options**: same as webpack minus webpack-only ones (`devDependencies`, `excludeUserRequest`). `exclude` matches resolved module ids; `lastIndex` is reset so a reused `/g`/`/y` regex stays deterministic. Relative `directory` is resolved to absolute before `require`.
- **Tests**: `npm test` builds and runs `test/vite.test.js` — covers `packageNameFromId` (incl. externals & built-ins), `generateBundle` (discovery, exclude, global-regex, relative dir, externals, rejection path), and the double-callback regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)